### PR TITLE
Move long notes to posts

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,6 +1,12 @@
 require_relative 'lib/shrink_and_optimize_images.rb'
+require_relative 'lib/move_long_notes_to_posts.rb'
 
-desc "Optimize image assets by dimensions and file size"
+desc 'Optimize image assets by dimensions and file size'
 task :optimize_images do
-  ShrinkAndOptimizeImages.new().execute
+  ShrinkAndOptimizeImages.new.execute
+end
+
+desc 'Take long Notes and move them into a temp folder to turn them into Posts'
+task :move_notes do
+  MoveLongNotesToPosts.new.execute
 end

--- a/_includes/layouts/base.liquid
+++ b/_includes/layouts/base.liquid
@@ -41,7 +41,7 @@
       </aside>
     {% endif %}
 
-    {% if pagination %}
+    {% if pagination and hidePagination != true %}
       <aside class="slant-top-right slant-bottom-padding border-primary-light">
         {% include pagination.liquid %}
       </aside>

--- a/lib/move_long_notes_to_posts.rb
+++ b/lib/move_long_notes_to_posts.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+class MoveLongNotesToPosts
+  NOTE_COUNT_LIMIT = 250
+  TO_POSTS_DIR = 'noteToPost'
+
+  def execute
+    unless File.directory?(TO_POSTS_DIR)
+      FileUtils.mkdir_p(TO_POSTS_DIR)
+    end
+
+    Dir.glob('notes/*.md') do |note|
+      count = number_of_words_in(note)
+
+      if count > NOTE_COUNT_LIMIT
+        FileUtils.mv(note, note.gsub('notes', TO_POSTS_DIR))
+      end
+    end
+  end
+
+  private
+
+  def number_of_words_in(file)
+    file = File.open(file)
+    word_count = 0
+
+    file.each_line do |line|
+      words_length = line.split.length
+      word_count += words_length
+    end
+
+    word_count
+  end
+end

--- a/notes/2020-02-14.md
+++ b/notes/2020-02-14.md
@@ -4,11 +4,11 @@ date: 2020-02-14
 
 Happy Valentine's Day. Today I shall rant about books.
 
-I gave "The Overton Window" a shot. I saw the author was Glenn Beck, the original political conspiracy theorist of my childhood. I saw the plot was a recycling of his usual ideas. I saw people giving me funny looks when I brought it home. I accepted all these things and tried to forget them as I read it like any other book.
+I gave "The Overton Window" a shot. I saw the author was Glenn Beck, the original political conspiracy theorist of my childhood. I accepted the funny looks others gave me and tried to read it like any other book.
 
-I tried, I did. But I could not finish it. But I'm certain it wasn't from my biases against this man. Instead, it was not a good book. It wasn't good for many reasons, but I'll focus on two big ones.
+I tried, I did, but couldn't finish. It wasn't due to any "liberal bias," it just wasn't a good book. There's many reasons for that, but here's two:
 
-1. **The dialogue is too preachy.** The dialogue so often reads like a broadcaster going through a block of text. Instead of reading like real people talking, as dialogue should. It takes the reader out of the story since it's more like a sermon than a narrative. It makes the characters feel like idea outlets than actual people. The dialogue rarely drives change or development. It gives you a giant wall of ideas and expects you to accept it and keep going. That may work for a news broadcast, but not for fiction.
-2. **It takes too long to get to the point.** The book flap teases a massive, country-shattering event as the hook. The book then doesn't reveal it until at least 45% into it. It should have happened at the 30% mark at the absolute latest. When a reader is getting bored waiting for the major plot events to happen, you're doing fiction wrong. Bait and delays are never worth it.
+1. **The dialogue is too preachy.** It reads like a broadcaster reading announcements instead of people talking. It dialogue rarely drives change or development when it's a giant wall of ideas it expects you to accept and keep going. That may work for an Aaron Sorkin series, but not fiction.
+2. **It takes too long to get to the point.** The book flap teases a massive, country-shattering event as the hook. Yet readers learn nothing until at least 45% into it, instead of the 30% mark at the absolute latest. When readers get bored waiting for the major plot events, you're doing fiction wrong.
 
-_I'm all for books having political views. I've read plenty along those lines along the spectrum. But I'm not for badly-written books._
+I'm all for books having political views, and have read plenty along the spectrum. But I'm not for badly-written books.

--- a/posts/2018-09-17-gods-evil-problem.md
+++ b/posts/2018-09-17-gods-evil-problem.md
@@ -1,6 +1,8 @@
 ---
-date: 2018-09-17
 title: "God's Evil Problem"
+date: "2018-09-17"
+excerpt: "'The Problem of Evil' seems to be used more to justify the world's existing evil."
+tags: ["tough stuff", "philosophy"]
 ---
 
 In all definitions of God I've heard, they're all-good, all-powerful, and all-knowing. I assume a God would need at least that much going for it to be worth worshipping.
@@ -16,6 +18,6 @@ A common response I've heard is it's all part of "God's Plan." Human's can't und
 
 First off, I'm worried that someone's willing to swallow a design where they'll never know the reason for so much suffering. Plus no one could understand if a design "beyond human understanding" was for the greater good. By definition, no one could know if this plan of God's is good or bad.
 
-Even worse is how someone could accept these evil designs in the name of "faith in those with power." That's the kind of belief those in power are happy for people to have. The same leaders who, coincidentally, preach religion as a source of morals and inspiration. **Makes me wonder if this answer to the "Problem of Evil" is how humans do so many evil things.**
+Even worse is how someone could accept these evil designs in the name of "faith in those with power." That's the kind of belief those in power are happy for people to have. The same leaders who, coincidentally, preach religion as a source of morals and inspiration. **Makes me wonder if this answer to the "Problem of Evil" is how humans justify doing so many evil things.**
 
 Instead of justifying evil to protect beliefs, people may be better off trying to understand the world's evil more, decrease it, and build their beliefs from there. Then would it really matter how much of a role "God" played?

--- a/posts/2018-09-19-passive-aggressive-perfectionist-fairy.md
+++ b/posts/2018-09-19-passive-aggressive-perfectionist-fairy.md
@@ -1,6 +1,8 @@
 ---
-date: 2018-09-19
 title: "The Passive-Aggressive Perfectionist Fairy"
+date: "2018-09-19"
+excerpt: "It's the fairy tormenting almost every aspect of my existence."
+tags: ["mental health", "tough stuff", "personal"]
 ---
 
 Cartoonist and web developer Rachel Nabors once drew [a comic about something she called the "Self-Doubt Fairy."](http://www.rachelthegreat.com/comics_stories/self-doubt-fairy/) I've found I have a similar voice in my head I call the "Passive-Aggressive Perfectionist Fairy," or PAP Fairy, and is just as bad for my mental health.

--- a/posts/2018-10-07-never-edgeworth.md
+++ b/posts/2018-10-07-never-edgeworth.md
@@ -1,12 +1,15 @@
 ---
-date: 2018-10-07
 title: "I'll Never be Edgeworth"
+date: "2018-10-07"
+excerpt: "Role models can be good for inspiration but bad for unrealistic standards."
+tags: ["personal", "anime"]
 ---
+
 I've always wanted to be more like, and had a mild man-crush on, Miles Edgeworth.
 
 What can I say, cravats are sexy. ❤️
 
-![Several snapshots of the fabulous Miles Edgeworth.](/assets/images/notes/edgeworth.jpg)
+<img class="post-content--partial-bleed" src="/assets/images/notes/edgeworth.jpg" alt="Several snapshots of the fabulous Miles Edgeworth." />
 
 You don't need to know who he is. Just that I've idealized Edgeworth, and others like him, for their eccentric level of intelligence. They effortlessly see the truth and stay two steps ahead of enemies. That's why people need them, and how they do so much good. He's like Dr. House, except working in law, is a more charming kind of jerk, and asexual.
 

--- a/posts/2018-11-28-meaning-behind-birthdays.md
+++ b/posts/2018-11-28-meaning-behind-birthdays.md
@@ -1,6 +1,8 @@
 ---
-date: 2018-11-28
 title: "Some Meaning Behind Birthdays"
+date: "2018-11-28"
+excerpt: "A new birthday lets my understanding of their importance evolve."
+tags: ["personal", "philosophy"]
 ---
 
 To be honest, I never thought birthdays were too important. The day I was born was a result of almost pure randomness and luck, which makes it hard to see it as meaningful. Before I saw birthdays as a measure of how much someone cares (too much) about aging. The more they care, the more of their attention is stuck on youth, aging, and having a portrait in their hallway reflect their inner ugliness while they pursue eternal youth.
@@ -11,9 +13,7 @@ Lately I've seen a different meaning that doesn't relate to the birthday person 
 
 So this note goes to the people who took a little time to wish me a happy birthday, either in person or online. It's a strong sign someone's grateful to know me, and I'm quite grateful for that in turn. As thanks, here's a gif of a corgi going off a water slide in slow motion.
 
-<div>
-  <img src="/assets/images/notes/corgi-water-slide.gif" style="margin: 0 auto; display: block; margin-bottom: 2rem;" />
-</div>
+<img class="mb-4" src="/assets/images/notes/corgi-water-slide.gif" alt="A corgi majestically jumping off a water slide into a pool." />
 
 This note also goes to myself, who after realizing all this, will actually try to wish others a happy birthday instead of realizing I forget in a panic several days later.
 

--- a/posts/2019-07-20-where-value-comes-from.md
+++ b/posts/2019-07-20-where-value-comes-from.md
@@ -1,5 +1,8 @@
 ---
-date: 2019-07-20
+title: "Where Does Value Come From?"
+date: "2019-07-20"
+excerpt: "A persistent question is what metrics we use to define the value of a human life."
+tags: ["tough stuff", "philosophy"]
 ---
 
 A question I constantly struggle with is **what gives someone's life value, and how I can find it for myself.**
@@ -8,7 +11,7 @@ Does a person's life have value if the person simply exists selfishly, looking o
 
 But devoting one's life to helping others doesn't fully solve it for me. It's nearly impossible to tell when the value one gives the world balances with what one takes to stay alive. Would one need to save one life to justify our own? Would one need to save one high-value life or several lower-value lives? Or give small bits of value and inspiration to lots of different people?
 
-<img class="block mx-auto width-75" src="/assets/images/notes/worth-life-manga.png" alt="Two panels from the 'Bungou Stray Dogs' manga with one character asking if saving others will truly make them worthy to live.">
+<img class="post-content--partial-bleed" class="block mx-auto width-75" src="/assets/images/notes/worth-life-manga.png" alt="Two panels from the 'Bungou Stray Dogs' manga with one character asking if saving others will truly make them worthy to live.">
 
 If one brings new life into this world with kids, does it only count if that life also brings value to the world? If someone produces a life that only takes and never gives, does that make one even _less_ worthy of life?
 

--- a/posts/2019-08-14-thirst-for-importance.md
+++ b/posts/2019-08-14-thirst-for-importance.md
@@ -1,5 +1,8 @@
 ---
-date: 2019-08-14
+title: "The Thirst for Importance"
+date: "2019-08-14"
+excerpt: "A person's natural urge to feel important, as natural as hunger and thirst, shows itself in many ways."
+tags: ["tough stuff", "philosophy"]
 ---
 
 One book I've been reading talked about a person's need to feel important. How it's so vital to one's well-being, it's on the same level of hunger and thirst. The more I considered it, the less absurd I realized it was.

--- a/posts/2019-11-24-coding-hands-dirty.md
+++ b/posts/2019-11-24-coding-hands-dirty.md
@@ -1,5 +1,8 @@
 ---
-date: 2019-11-24
+title: "Getting my Coding Hands Dirty"
+date: "2019-11-24"
+excerpt: "It's important to read and write about how I learn to code, as long as it doesn't detract from writing actual code."
+tags: ["career"]
 ---
 
 There are many ways for programmers to learn and improve, such as:

--- a/posts/2019-12-10-tech-bias-against-women.md
+++ b/posts/2019-12-10-tech-bias-against-women.md
@@ -1,5 +1,8 @@
 ---
-date: 2019-12-10
+title: "Tech and its Bias Against Women"
+date: "2019-12-10"
+excerpt: "It's hard to escape the dominant tech assumption that a woman-dominated isn't 'normal.'"
+tags: ["tough stuff", "career"]
 ---
 
 Recently in a local Slack group, I shared a tweet from someone dissing Ruby on Rails. While this is unforgivable, that's not what this note is about. Part of the context was a woman being hired in an all-women company.

--- a/posts/2020-02-16-innate-danger-moderates.md
+++ b/posts/2020-02-16-innate-danger-moderates.md
@@ -1,5 +1,8 @@
 ---
-date: 2020-02-16
+title: "The Innate Danger of Moderates"
+date: "2020-02-16"
+excerpt: "If you think moderate positions are the 'high ground,' know that civil rights leaders thought it was a bigger threat than extremists."
+tags: ["tough stuff", "philosophy"]
 ---
 
 This note is for people who see anger and criticism for aspects of today's society. Instead of supporting it, they call it "disruptive" or "too angry." I have a small history lesson for you.
@@ -11,3 +14,5 @@ During the civil rights movement, plenty of white moderates supported civil righ
 The short version: these moderates understood issues in the abstract. But they never experienced the cruel effects firsthand. **They say the status quo should change but have no desire to change it - often because they benefit even at others' expense.** So they dismiss any push to change the status quo as disruptive. Even if it's for a cause they "support."
 
 Yes, these efforts are disruptive. By definition, one needs to disrupt a bad system to fix it. You need to tear out a broken pipe to put in a better on. Dismissing these efforts as "people only looking for attention" exposes one's privilege fast. They never had to fight what so many others do each day.
+
+If you truly care about others and their rights, you need to accept the sacrifices that come with that. This includes giving a little on your own, so groups can collectively get what they needed but were deprived of for centuries.

--- a/posts/2020-05-23-dont-abdicate-work-to-heroes.md
+++ b/posts/2020-05-23-dont-abdicate-work-to-heroes.md
@@ -1,5 +1,8 @@
 ---
-date: 2020-05-23
+title: "Don't Abdicate Work to the 'Heroes'"
+date: "2020-05-23"
+excerpt: "Giving thanks to others should not be an excuse to avoid your share of work in a pandemic."
+tags: ["coronavirus", "tough stuff"]
 ---
 
 Imagine a group of people living in a home. They gather piles of dry wood everywhere. They vageuely know it's a bad idea and it'll eventually cause some kind of disaster but do nothing else. Then one day there's a spark, the dry wood catches fire, and the house is set ablaze.

--- a/posts/2020-05-27-ambiguities-nazi-germany-power.md
+++ b/posts/2020-05-27-ambiguities-nazi-germany-power.md
@@ -1,5 +1,8 @@
 ---
-date: 2020-05-27
+title: "The Ambiguities as Nazi Germany Rose To Power"
+date: "2020-05-27"
+excerpt: "Nazi Germany is universally seen as bad now, but it happened much later than many today would have expected."
+tags: ["tough stuff"]
 ---
 
 I recently read [a book about life in Nazi Germany leading up to World War II](https://www.amazon.com/Garden-Beasts-Terror-American-Hitlers-ebook/dp/B004HFRJM6). What struck me most was how ambiguous and mixed peoples' feelings were. Today the horrors of the Nazi Party are black and white, but not leading up to the war.

--- a/posts/2020-07-14-let-them-eat-cricket-cake.md
+++ b/posts/2020-07-14-let-them-eat-cricket-cake.md
@@ -1,5 +1,8 @@
 ---
-date: 2020-07-14
+title: "Let Them Eat Cricket Cake"
+date: "2020-07-14"
+excerpt: "It's fun to imagine the future of widespread, sustainable eating could be eating crickets. In many different forms."
+tags: ["other", "tough stuff"]
 ---
 
 As delicious as meat is, eating it is unsustainable for the planet. But I read something surprising: [we could help save the world be swapping meat with insects](https://www.nbcnews.com/mach/environment/how-eating-crickets-could-help-save-planet-n721416).

--- a/posts/2020-07-21-healthy-controlling-anger.md
+++ b/posts/2020-07-21-healthy-controlling-anger.md
@@ -1,5 +1,8 @@
 ---
-date: 2020-07-21
+title: "Keeping Healthy by Controlling Anger"
+date: "2020-07-21"
+excerpt: "Anger shouldn't motivate us at the cost of our physical health, even amid injustice in a pandemic."
+tags: ["coronavirus", "mental health"]
 ---
 
 During this particular pandemic, there are lots of people I'm understandably angry at:

--- a/tags.liquid
+++ b/tags.liquid
@@ -14,6 +14,7 @@ layout: layouts/page.liquid
 eleventyComputed:
   title: Tagged "{{ tag }}"
 permalink: /tags/{{ tag }}/
+hidePagination: true
 ---
 
 {% assign posts = collections[tag] | reverse %}


### PR DESCRIPTION
Some notes are a bit too long to call them posts. This adds a script that moves long notes away so I can manually convert them to simple posts.